### PR TITLE
Implements Item History

### DIFF
--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -55,7 +55,7 @@ class Postgres {
             floatid     bigint  NOT NULL,
             a           bigint  NOT NULL,
             steamid     bigint  NOT NULL,
-            time        timestamp NOT NULL,
+            created_at  timestamp NOT NULL,
             PRIMARY KEY (floatid, a)
         );
 

--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -79,7 +79,7 @@ class Postgres {
             RETURN TRUE;
         END;$BODY$;
         
-        CREATE OR REPLACE FUNCTION update_history()
+        CREATE OR REPLACE FUNCTION extend_history()
         RETURNS TRIGGER
         AS $$
         BEGIN
@@ -98,14 +98,14 @@ class Postgres {
         $$
         LANGUAGE 'plpgsql';
 
-        DROP TRIGGER IF EXISTS update_history_trigger
+        DROP TRIGGER IF EXISTS extend_history_trigger
             ON items;
 
-        CREATE TRIGGER update_history_trigger
+        CREATE TRIGGER extend_history_trigger
             BEFORE UPDATE ON items
             FOR EACH ROW
             WHEN (OLD.a < NEW.a)
-            EXECUTE PROCEDURE update_history();
+            EXECUTE PROCEDURE extend_history();
 
         CREATE OR REPLACE FUNCTION ensure_floatid()
         RETURNS TRIGGER

--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -47,14 +47,100 @@ class Postgres {
             stickers    jsonb,
             updated     timestamp NOT NULL,
             rarity      smallint NOT NULL,
+            floatid     bigint  NOT NULL,
             PRIMARY KEY (a)
-        )`);
+        );
+
+        CREATE TABLE IF NOT EXISTS history (
+            floatid     bigint  NOT NULL,
+            a           bigint  NOT NULL,
+            steamid     bigint  NOT NULL,
+            time        timestamp NOT NULL,
+            PRIMARY KEY (floatid, a)
+        );
+
+        ALTER TABLE items ADD COLUMN IF NOT EXISTS floatid BIGINT;
+
+        -- Float ID is defined as the first asset id we've seen for an item
+
+        CREATE OR REPLACE FUNCTION is_steamid(IN val bigint)
+            RETURNS boolean
+            LANGUAGE 'plpgsql'
+            PARALLEL SAFE
+        AS $BODY$BEGIN
+            IF val < 76561197960265728 THEN
+                RETURN FALSE;
+            ELSIF (val >> 56) > 5 THEN
+                RETURN FALSE;
+            ELSIF ((val >> 32) & ((1 << 20) - 1)) > 32 THEN
+                RETURN FALSE;
+            END IF;
+        
+            RETURN TRUE;
+        END;$BODY$;
+        
+        CREATE OR REPLACE FUNCTION update_history()
+        RETURNS TRIGGER
+        AS $$
+        DECLARE
+            floatid BIGINT;
+        BEGIN
+            -- Handle cases where the floatid isn't there
+            IF NEW.floatid IS NOT NULL THEN
+                floatid = NEW.floatid;
+            ELSE
+                -- Update the DB with the floatid if it still doesn't exist
+                UPDATE items SET floatid=OLD.a WHERE a=NEW.a;
+                floatid = OLD.a;
+            END IF;
+
+            IF is_steamid(OLD.ms) THEN
+                -- We only care about history for inventory changes
+                INSERT INTO history VALUES (floatid, OLD.a, OLD.ms, OLD.updated);
+            END IF;
+
+            RETURN NEW;
+        END;
+        $$
+        LANGUAGE 'plpgsql';
+
+        DROP TRIGGER IF EXISTS update_history_trigger
+            ON items;
+
+        CREATE TRIGGER update_history_trigger
+            AFTER UPDATE ON items
+            FOR EACH ROW
+            WHEN (OLD.a < NEW.a)
+            EXECUTE PROCEDURE update_history();
+
+        CREATE OR REPLACE FUNCTION ensure_floatid()
+        RETURNS TRIGGER
+        AS $$
+        BEGIN
+            IF NEW.floatid IS NULL THEN
+                NEW.floatid = NEW.a;
+            END IF;
+            
+            RETURN NEW;
+        END;
+        $$
+        LANGUAGE 'plpgsql';
+
+        DROP TRIGGER IF EXISTS ensure_floatid_trigger
+            ON items;
+
+        CREATE TRIGGER ensure_floatid_trigger
+            BEFORE INSERT ON items
+            FOR EACH ROW
+            EXECUTE PROCEDURE ensure_floatid();
+        `);
 
         await this.pool.query(`CREATE INDEX IF NOT EXISTS i_stickers ON items USING gin (stickers jsonb_path_ops) 
                                 WHERE stickers IS NOT NULL`);
         await this.pool.query(`CREATE INDEX IF NOT EXISTS i_paintwear ON items (paintwear)`);
         await this.pool.query(`CREATE UNIQUE INDEX IF NOT EXISTS i_unique_item ON 
                                 items (defindex, paintindex, paintwear, paintseed)`);
+        await this.pool.query(`CREATE UNIQUE INDEX IF NOT EXISTS i_unique_fid ON items (floatid)`);
     }
 
     async insertItemData(item) {

--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -82,21 +82,15 @@ class Postgres {
         CREATE OR REPLACE FUNCTION update_history()
         RETURNS TRIGGER
         AS $$
-        DECLARE
-            floatid BIGINT;
         BEGIN
             -- Handle cases where the floatid isn't there
-            IF NEW.floatid IS NOT NULL THEN
-                floatid = NEW.floatid;
-            ELSE
-                -- Update the DB with the floatid if it still doesn't exist
-                UPDATE items SET floatid=OLD.a WHERE a=NEW.a;
-                floatid = OLD.a;
+            IF NEW.floatid IS NULL THEN
+                NEW.floatid = OLD.a;
             END IF;
 
             IF is_steamid(OLD.ms) AND OLD.ms != NEW.ms THEN
                 -- We only care about history for inventory changes
-                INSERT INTO history VALUES (floatid, OLD.a, OLD.ms, OLD.updated);
+                INSERT INTO history VALUES (NEW.floatid, OLD.a, OLD.ms, OLD.updated);
             END IF;
 
             RETURN NEW;
@@ -108,7 +102,7 @@ class Postgres {
             ON items;
 
         CREATE TRIGGER update_history_trigger
-            AFTER UPDATE ON items
+            BEFORE UPDATE ON items
             FOR EACH ROW
             WHEN (OLD.a < NEW.a)
             EXECUTE PROCEDURE update_history();

--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -94,7 +94,7 @@ class Postgres {
                 floatid = OLD.a;
             END IF;
 
-            IF is_steamid(OLD.ms) THEN
+            IF is_steamid(OLD.ms) AND OLD.ms != NEW.ms THEN
                 -- We only care about history for inventory changes
                 INSERT INTO history VALUES (floatid, OLD.a, OLD.ms, OLD.updated);
             END IF;


### PR DESCRIPTION
* Creates a backwards compatible way to store item updates in a separate table
* Creates the notion of a `Float ID` which is the first asset ID we've seen for an item
* Items are now defined by a unique float id, where you can fetch their history using this ID
* Only Steam Inventory changes are saved in history
* Allows outdated CSGOFloat versions to coexist while other servers are updated

While it isn't absolutely necessary, it is recommended to copy all the existing asset ids into the floatid column when upgrading.